### PR TITLE
Change JDKs Travis uses since oracle one was dropped.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 install: mvn -Pstaging install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn -Pstaging test -B
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 cache:
   directories:


### PR DESCRIPTION
The default images (Ubuntu Xenial I think?) Travis uses for testing dropped oracle JDK 8 some time ago.
This PR sets it to use openjdk 8 and 11 instead.