### PR TITLE
Configure surefire to fix crash on security manager tests

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -355,6 +355,7 @@
 								<include>**/privileged/**</include>
 							</includes>
 							<argLine>-Djava.security.manager -Djava.security.policy=${project.build.testOutputDirectory}/java.policy</argLine>
+							<forkCount>0</forkCount>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
An attempt to fix jenkins crash
see https://issues.apache.org/jira/browse/SUREFIRE-1588
