### PR TITLE
Fixed parent version number in cdi-spec pom file

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.ee4j.cdi</groupId>
 		<artifactId>cdi-parent</artifactId>
-		<version>2.0.2-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jakarta.enterprise.cdi-spec-doc</artifactId>


### PR DESCRIPTION
The parent version of the spec module is still referring to the old one. This PR fixes that.