### PR TITLE
Check configuredProvider that it holds valid CDI container.

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
@@ -66,27 +66,39 @@ public abstract class CDI<T> implements Instance<T> {
 
     /**
      *
-     * Obtain the {@link CDIProvider} the user set with {@link #setCDIProvider(CDIProvider)}, or if it wasn't set, use the
-     * serviceloader the retrieve the {@link CDIProvider} with the highest priority.
+     * Obtain the {@link CDIProvider} the user set with {@link #setCDIProvider(CDIProvider)} or the last returned
+     * {@link CDIProvider} if it returns valid CDI container. Otherwise use the serviceloader to retrieve the
+     * {@link CDIProvider} with the highest priority.
      *
      * @return the {@link CDIProvider} set by user or retrieved by serviceloader
      */
     private static CDIProvider getCDIProvider() {
-        if (configuredProvider != null) {
-            return configuredProvider;
-        } else {
-            // Discover providers and cache
-            if (discoveredProviders == null) {
-                synchronized (lock) {
-                    if (discoveredProviders == null) {
-                        findAllProviders();
-                    }
+        try {
+            if (configuredProvider != null && configuredProvider.getCDI() != null) {
+                return configuredProvider;
+            }
+        } catch (IllegalStateException ignored) {
+        }
+        configuredProvider = null;
+        // Discover providers and cache
+        if (discoveredProviders == null) {
+            synchronized (lock) {
+                if (discoveredProviders == null) {
+                    findAllProviders();
                 }
             }
-            configuredProvider = discoveredProviders.stream()
-                    .filter(c -> c.getCDI() != null)
-                    .findFirst().orElseThrow(() -> new IllegalStateException("Unable to access CDI"));
-            return configuredProvider;
+        }
+        configuredProvider = discoveredProviders.stream()
+                .filter(CDI::checkProvider)
+                .findFirst().orElseThrow(() -> new IllegalStateException("Unable to access CDI"));
+        return configuredProvider;
+    }
+
+    private static boolean checkProvider(CDIProvider c) {
+        try {
+            return c.getCDI() != null;
+        } catch (IllegalStateException e) {
+            return false;
         }
     }
 

--- a/api/src/test/java/org/jboss/cdi/api/test/CDITest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/CDITest.java
@@ -153,4 +153,14 @@ public class CDITest {
         fw.close();
         CDI.current();
     }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testForClosedContainer() throws Exception {
+        FileWriter fw = new FileWriter(SERVICE_FILE_NAME);
+        fw.write(ClosableCDIProvider.class.getName());
+        fw.close();
+        CDI.current();
+        ClosableCDIProvider.closeContainer();
+        CDI.current();
+    }
 }

--- a/api/src/test/java/org/jboss/cdi/api/test/ClosableCDIProvider.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/ClosableCDIProvider.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.api.test;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.*;
+import javax.enterprise.util.TypeLiteral;
+import java.lang.annotation.Annotation;
+import java.util.Iterator;
+
+/**
+ * Created by antoine on 16/12/2015.
+ */
+public class ClosableCDIProvider implements CDIProvider {
+
+    private static CDI<Object> cdiInstance = new DummyCDI();
+
+    static void closeContainer() {
+        cdiInstance = null;
+    }
+
+    @Override
+    public CDI<Object> getCDI() {
+        return cdiInstance;
+    }
+
+    @Override
+    public int getPriority() {
+        return 20;
+    }
+
+    public static class DummyCDI extends CDI<Object> {
+
+
+        @Override
+        public BeanManager getBeanManager() {
+            return null;
+        }
+
+        @Override
+        public Instance<Object> select(Annotation... qualifiers) {
+            return null;
+        }
+
+        @Override
+        public <U> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+            return null;
+        }
+
+        @Override
+        public <U> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            return null;
+        }
+
+        @Override
+        public boolean isUnsatisfied() {
+            return false;
+        }
+
+        @Override
+        public boolean isAmbiguous() {
+            return false;
+        }
+        
+        @Override
+        public void destroy(Object instance) {
+
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+            return null;
+        }
+
+        @Override
+        public Object get() {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Check for both IllegalStateException and null value when filtering discovered providers.

Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>