### PR TITLE
Add EJB dependency only as JavaDoc dep.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -177,11 +177,6 @@
 				<artifactId>jakarta.transaction-api</artifactId>
 				<version>${transaction.api.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>jakarta.ejb</groupId>
-				<artifactId>jakarta.ejb-api</artifactId>
-				<version>${ejb.api.version}</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -204,11 +199,6 @@
 		<dependency>
 			<groupId>jakarta.transaction</groupId>
 			<artifactId>jakarta.transaction-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.ejb</groupId>
-			<artifactId>jakarta.ejb-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 
@@ -377,6 +367,13 @@ Comments to: <a href="mailto:cdi-dev@eclipse.org">cdi-dev@eclipse.org</a>.<br>
 Copyright &#169; 2018,2020 Eclipse Foundation.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 					</bottom>
+					<additionalDependencies>
+						<additionalDependency>
+							<groupId>jakarta.ejb</groupId>
+							<artifactId>jakarta.ejb-api</artifactId>
+							<version>${ejb.api.version}</version>
+						</additionalDependency>
+					</additionalDependencies>
 				</configuration>
 
 				<executions>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/SessionBeanType.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/SessionBeanType.java
@@ -16,8 +16,6 @@
  */
 package jakarta.enterprise.inject.spi;
 
-import jakarta.ejb.Stateless;
-
 /**
  * Identifies the kind of EJB session bean.
  * 


### PR DESCRIPTION
Recent merge of [some of the missing changes from 3.0 branch](https://github.com/eclipse-ee4j/cdi/commit/7a55f23bcd0d901a336d8b4b6dc0402c486c7368#diff-8658bb96fff6ac848cd28d3242fce067) caused re-introduction of EJB dependency when it is only really needed for Javadoc. I have bumped into this when building a shaded jar javadoc containing CDI API which now requires me to add EJB dep as well.

This PR removes EJB dep and only introduces it as additional javadoc dependency.