### PR TITLE
Correction to wording of EventMetadata#getInjectionPoint

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/EventMetadata.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/EventMetadata.java
@@ -51,8 +51,7 @@ public interface EventMetadata {
     public Set<Annotation> getQualifiers();
 
     /**
-     * Get the {@link InjectionPoint} representing the injected {@link Event} instance which fired the event, or
-     * <code>null</code> if it was fired from {@link BeanManager#getEvent()}
+     * Get the {@link InjectionPoint} representing the injected {@link Event} instance which fired the event
      *
      * @return InjectionPoint of the Event
      */


### PR DESCRIPTION
This is an oversight from https://github.com/eclipse-ee4j/cdi/pull/473 where the wording was incorrectly changed.

The only case in which `null` was to be returned was `BM.fireEvent()`.
We even had a TCK that asserted just that, see https://github.com/eclipse-ee4j/cdi-tck/blob/3.0.2/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/EventMetadataTest.java