### PR TITLE
Cleanup AnnotationInfo/Annotation Target

### DIFF
--- a/api/src/main/java/jakarta/enterprise/lang/model/AnnotationInfo.java
+++ b/api/src/main/java/jakarta/enterprise/lang/model/AnnotationInfo.java
@@ -13,14 +13,14 @@ public interface AnnotationInfo {
      *
      * @return target of this annotation
      */
-    AnnotationTarget target();
+    AnnotationTarget getTarget();
 
     /**
      * Declaration of this annotation's type.
      *
      * @return declaration of this annotation
      */
-    ClassInfo<?> declaration();
+    ClassInfo<?> getDeclaration();
 
     /**
      * Fully qualified name of this annotation.
@@ -28,8 +28,8 @@ public interface AnnotationInfo {
      *
      * @return fully qualified name of this annotation
      */
-    default String name() {
-        return declaration().name();
+    default String getName() {
+        return getDeclaration().name();
     }
 
     /**
@@ -39,7 +39,7 @@ public interface AnnotationInfo {
      * @return whether this annotation is repeatable
      */
     default boolean isRepeatable() {
-        return declaration().hasAnnotation(Repeatable.class);
+        return getDeclaration().hasAnnotation(Repeatable.class);
     }
 
     /**
@@ -57,14 +57,14 @@ public interface AnnotationInfo {
      * @param name attribute name
      * @return value of this annotation's attribute with given {@code name}
      */
-    AnnotationAttributeValue attribute(String name);
+    AnnotationAttributeValue getAttribute(String name);
 
     default boolean hasValue() {
         return hasAttribute("value");
     }
 
-    default AnnotationAttributeValue value() {
-        return attribute("value");
+    default AnnotationAttributeValue getValue() {
+        return getAttribute("value");
     }
 
     /**
@@ -72,5 +72,5 @@ public interface AnnotationInfo {
      *
      * @return all attributes of this annotation
      */
-    Collection<AnnotationAttribute> attributes();
+    Collection<AnnotationAttribute> getAttributes();
 }

--- a/api/src/main/java/jakarta/enterprise/lang/model/AnnotationTarget.java
+++ b/api/src/main/java/jakarta/enterprise/lang/model/AnnotationTarget.java
@@ -2,6 +2,7 @@ package jakarta.enterprise.lang.model;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -18,16 +19,65 @@ public interface AnnotationTarget {
     // TODO specify equals/hashCode (for the entire .lang.model hierarchy)
     // TODO settle on using Optional everywhere, or allowing null everywhere; it's a mix right now
 
-    boolean hasAnnotation(Class<? extends Annotation> annotationType);
+    /**
+     * Returns whether an annotation is present on this annotation target.
+     * @param annotationType The annotation type.
+     * @return <code>true</code> if the given annotation type is present or <code>false</code> of the given annotation type is <code>null</code> or not present
+     */
+    boolean hasAnnotation(String annotationType);
 
+    /**
+     * Returns whether an annotation is present on this annotation target.
+     * @param annotationType The annotation type.
+     * @return <code>true</code> if the given annotation type is present or <code>false</code> of the given annotation type is <code>null</code> or not present
+     */
+    default boolean hasAnnotation(Class<? extends Annotation> annotationType) {
+        return hasAnnotation(annotationType.getName());
+    }
+
+    /**
+     * Returns <code>true</code> if any annotation is present that matches the passed predicate.
+     * @param predicate The predicate which receives an {@link jakarta.enterprise.lang.model.AnnotationInfo}
+     * @return <code>true</code> if the given predicate matches any annotation
+     */
     boolean hasAnnotation(Predicate<AnnotationInfo> predicate);
 
-    // TODO what if missing?
-    AnnotationInfo annotation(Class<? extends Annotation> annotationType);
+    /**
+     * Retrieves an annotation of the given type name.
+     * @param annotationType The annotation type
+     * @return An {@link jakarta.enterprise.lang.model.AnnotationInfo} if present
+     */
+    Optional<AnnotationInfo> getAnnotation(String annotationType);
 
-    Collection<AnnotationInfo> repeatableAnnotation(Class<? extends Annotation> annotationType);
+    /**
+     * Retrieves an annotation of the given type.
+     * @param annotationType The annotation type
+     * @return An {@link jakarta.enterprise.lang.model.AnnotationInfo} if present
+     */
+    default Optional<AnnotationInfo> getAnnotation(Class<? extends Annotation> annotationType) {
+        return getAnnotation(annotationType.getName());
+    }
 
-    Collection<AnnotationInfo> annotations(Predicate<AnnotationInfo> predicate);
+    /**
+     * Obtains a collection of zero or many repeated {@link jakarta.enterprise.lang.model.AnnotationInfo} instances
+     * for the given repeatable annotation type.
+     *
+     * <p>The passed type should be an annotation that is meta annotated with {@link java.lang.annotation.Repeatable}.</p>
+     *
+     * @param annotationType The annotation repeatable type. That is the a
+     * @return An immutable collection of {@link jakarta.enterprise.lang.model.AnnotationInfo}
+     */
+    Collection<AnnotationInfo> getRepeatableAnnotations(Class<? extends Annotation> annotationType);
 
-    Collection<AnnotationInfo> annotations();
+    /**
+     * Resolves all of the {@link jakarta.enterprise.lang.model.AnnotationInfo} instances that match the given predicate.
+     * @param predicate The predicate
+     * @return An immutable collection of {@link jakarta.enterprise.lang.model.AnnotationInfo} instances
+     */
+    Collection<AnnotationInfo> getAnnotations(Predicate<AnnotationInfo> predicate);
+
+    /**
+     * @return An immutable collection of {@link jakarta.enterprise.lang.model.AnnotationInfo} instances
+     */
+    Collection<AnnotationInfo> getAnnotations();
 }

--- a/api/src/main/java/jakarta/enterprise/lang/model/AnnotationTarget.java
+++ b/api/src/main/java/jakarta/enterprise/lang/model/AnnotationTarget.java
@@ -1,7 +1,5 @@
 package jakarta.enterprise.lang.model;
 
-import jakarta.enterprise.lang.model.declarations.DeclarationInfo;
-import jakarta.enterprise.lang.model.types.Type;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.function.Predicate;
@@ -12,21 +10,13 @@ import java.util.function.Predicate;
  *
  * <ul>
  * <li>a <i>declaration</i>, such as a class, method, field, etc.</li>
- * <li>a <i>type parameter</i>, occuring in class declarations and method declarations</li>
+ * <li>a <i>type parameter</i>, occurring in class declarations and method declarations</li>
  * <li>a <i>type use</i>, such as a type of method parameter, a type of field, a type argument, etc.</li>
  * </ul>
  */
 public interface AnnotationTarget {
     // TODO specify equals/hashCode (for the entire .lang.model hierarchy)
     // TODO settle on using Optional everywhere, or allowing null everywhere; it's a mix right now
-
-    boolean isDeclaration();
-
-    boolean isType();
-
-    DeclarationInfo asDeclaration();
-
-    Type asType();
 
     boolean hasAnnotation(Class<? extends Annotation> annotationType);
 

--- a/api/src/main/java/jakarta/enterprise/lang/model/declarations/DeclarationInfo.java
+++ b/api/src/main/java/jakarta/enterprise/lang/model/declarations/DeclarationInfo.java
@@ -18,26 +18,6 @@ public interface DeclarationInfo extends AnnotationTarget {
     // TODO reevaluate the is*/as*/kind() approach (everywhere!); maybe type checks and casts are better, maybe
     //  something completely different is even better
 
-    @Override
-    default boolean isDeclaration() {
-        return true;
-    }
-
-    @Override
-    default boolean isType() {
-        return false;
-    }
-
-    @Override
-    default DeclarationInfo asDeclaration() {
-        return this;
-    }
-
-    @Override
-    default Type asType() {
-        throw new IllegalStateException("Not a type");
-    }
-
     enum Kind {
         /** Packages can be annotated in {@code package-info.java}. */
         PACKAGE,

--- a/api/src/main/java/jakarta/enterprise/lang/model/types/Type.java
+++ b/api/src/main/java/jakarta/enterprise/lang/model/types/Type.java
@@ -1,7 +1,6 @@
 package jakarta.enterprise.lang.model.types;
 
 import jakarta.enterprise.lang.model.AnnotationTarget;
-import jakarta.enterprise.lang.model.declarations.DeclarationInfo;
 
 /**
  * Types are:
@@ -17,25 +16,6 @@ import jakarta.enterprise.lang.model.declarations.DeclarationInfo;
  * </ul>
  */
 public interface Type extends AnnotationTarget {
-    @Override
-    default boolean isDeclaration() {
-        return false;
-    }
-
-    @Override
-    default boolean isType() {
-        return true;
-    }
-
-    @Override
-    default DeclarationInfo asDeclaration() {
-        throw new IllegalStateException("Not a declaration");
-    }
-
-    @Override
-    default Type asType() {
-        return this;
-    }
 
     enum Kind {
         /** E.g. when method returns {@code void}. */


### PR DESCRIPTION
I am starting to progress the build extensions impl and I think we should agree on a few things before I try put effort into API cleanup so I created this draft for discussion:

* The rest of the CDI spec uses `get*` methods for accessors so I think we should remain consistent with the rest of the API otherwise it seems a bit odd that the new model API doesn't follow the convention of the rest of the spec
* In general I think we should do away with type coercion methods like `asType`, `asDeclaration` and the rest. It seems like an artefact of Jandex but Java has a type system with `instanceof` and recent Java has pattern matching so it seems completely unneeded and error prone

If we agree that we should stick to `get*` I can progressively try and cleanup and javadoc more of this API to try to add some clarity to it.