### PR TITLE
Make addContext accept the annotation type

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ContextConfig.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ContextConfig.java
@@ -7,29 +7,26 @@ import jakarta.enterprise.context.spi.AlterableContext;
  * Allows configuring custom scope and context. The only mandatory method is
  * {@link ContextConfig#implementation(Class)}, other methods are optional.
  * If they aren't called, correct value is deduced from the context implementation class.
+ *
+ * @param <A> The annotation type
  */
-public interface ContextConfig {
+public interface ContextConfig<A extends Annotation> {
     /**
      * If implementation class is defined using {@link #implementation(Class)},
      * this method doesn't have to be called. If it is, it overrides the scope annotation
      * as defined by the implementation class.
      *
-     * @param scopeAnnotation scope annotation of the context
-     * @return this {@code ContextConfig}
+     * @return The scope of the context configuration, never {@code null}
      */
-    // TODO if called multiple times, last call wins? or only allow calling once?
-    ContextConfig scope(Class<? extends Annotation> scopeAnnotation);
+    Class<A> scope();
 
     /**
-     * If scope annotation is defined using {@link #scope(Class)},
-     * this method doesn't have to be called. If it is, it overrides the normal/pseudo state
-     * as defined by the scope annotation.
+     * Overrides the normal/pseudo state as defined by the scope annotation.
      *
      * @param isNormal whether the scope is normal
-     * @return this {@code ContextConfig}
+     * @return this {@code ContextConfig}, never {@code null}
      */
-    // TODO if called multiple times, last call wins? or only allow calling once?
-    ContextConfig normal(boolean isNormal);
+    ContextConfig<A> normal(boolean isNormal);
 
     /**
      * Defines the context implementation class. It must be {@code public} and
@@ -37,11 +34,10 @@ public interface ContextConfig {
      * <p>
      * The implementation class typically provides the scope annotation, and therefore
      * also whether the scope is a normal scope or pseudoscope, but this can be overridden
-     * using {@link #scope(Class)} and {@link #normal(boolean)}.
+     * using {@link #normal(boolean)}.
      *
      * @param implementationClass context object implementation class
-     * @return this {@code ContextConfig}
+     * @return this {@code ContextConfig}, never {@code null}
      */
-    // TODO if called multiple times, last call wins? or only allow calling once?
-    ContextConfig implementation(Class<? extends AlterableContext> implementationClass);
+    ContextConfig<A> implementation(Class<? extends AlterableContext> implementationClass);
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/MetaAnnotations.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/MetaAnnotations.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
  * @see #addQualifier(Class, Consumer)
  * @see #addInterceptorBinding(Class, Consumer)
  * @see #addStereotype(Class, Consumer)
- * @see #addContext()
+ * @see #addContext(Class)
  */
 public interface MetaAnnotations {
     // TODO this API style is not very common, and makes addContext too different
@@ -46,7 +46,8 @@ public interface MetaAnnotations {
     /**
      * Registers custom context as configured by the returned {@link ContextConfig}.
      *
+     * @param annotationType The annotation type, never {@code null}
      * @return custom context configurator, never {@code null}
      */
-    ContextConfig addContext();
+    <A extends Annotation> ContextConfig<A> addContext(Class<A> annotationType);
 }


### PR DESCRIPTION
AlterableContext doesn't take a generic argument and there is no way to know the
 actual scope annotation without instantiating it so this change makes the scope
 annotation required.﻿