### PR TITLE
improve extension API documentation and resolve some open questions

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ClassConfig.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ClassConfig.java
@@ -1,8 +1,11 @@
 package jakarta.enterprise.inject.build.compatible.spi;
 
+import jakarta.enterprise.lang.model.AnnotationInfo;
 import jakarta.enterprise.lang.model.declarations.ClassInfo;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
  * Allows adding annotations to and removing annotations from a class.
@@ -12,7 +15,7 @@ import java.util.Collection;
  * @see Enhancement
  * @since 4.0
  */
-public interface ClassConfig extends DeclarationConfig<ClassConfig> {
+public interface ClassConfig extends DeclarationConfig {
     // TODO now that ClassInfo also returns inherited annotations, need to think about what happens
     //  when we add an annotation that collides with an inherited one, or when we remove an inherited annotation
 
@@ -23,6 +26,53 @@ public interface ClassConfig extends DeclarationConfig<ClassConfig> {
      */
     @Override
     ClassInfo info();
+
+    /**
+     * Adds a marker annotation of given type to this class.
+     * Doesn't allow configuring annotation members.
+     *
+     * @param annotationType the annotation type, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    ClassConfig addAnnotation(Class<? extends Annotation> annotationType);
+
+    /**
+     * Adds given annotation to this class. The {@link AnnotationInfo} can be obtained
+     * from an annotation target, or constructed from scratch using {@link AnnotationBuilder}.
+     *
+     * @param annotation the annotation to add to this class, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    ClassConfig addAnnotation(AnnotationInfo annotation);
+
+    /**
+     * Adds given annotation to this class. The annotation instance is typically
+     * a subclass of {@link jakarta.enterprise.util.AnnotationLiteral AnnotationLiteral}.
+     *
+     * @param annotation the annotation to add to this class, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    ClassConfig addAnnotation(Annotation annotation);
+
+    /**
+     * Removes all annotations matching given predicate from this class.
+     *
+     * @param predicate an annotation predicate, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    ClassConfig removeAnnotation(Predicate<AnnotationInfo> predicate);
+
+    /**
+     * Removes all annotations from this class.
+     *
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    ClassConfig removeAllAnnotations();
 
     /**
      * Returns a collection of {@link MethodConfig} objects for each constructor of this class.

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/DeclarationConfig.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/DeclarationConfig.java
@@ -14,7 +14,7 @@ import java.util.function.Predicate;
  * @see Enhancement
  * @since 4.0
  */
-public interface DeclarationConfig<THIS extends DeclarationConfig<THIS>> {
+public interface DeclarationConfig {
     /**
      * Returns the {@link DeclarationInfo} corresponding to this transformed declaration.
      *
@@ -29,7 +29,7 @@ public interface DeclarationConfig<THIS extends DeclarationConfig<THIS>> {
      * @param annotationType the annotation type, must not be {@code null}
      * @return this configurator object, to allow fluent usage
      */
-    THIS addAnnotation(Class<? extends Annotation> annotationType);
+    DeclarationConfig addAnnotation(Class<? extends Annotation> annotationType);
 
     /**
      * Adds given annotation to this declaration. The {@link AnnotationInfo} can be obtained
@@ -38,7 +38,7 @@ public interface DeclarationConfig<THIS extends DeclarationConfig<THIS>> {
      * @param annotation the annotation to add to this declaration, must not be {@code null}
      * @return this configurator object, to allow fluent usage
      */
-    THIS addAnnotation(AnnotationInfo annotation);
+    DeclarationConfig addAnnotation(AnnotationInfo annotation);
 
     /**
      * Adds given annotation to this declaration. The annotation instance is typically
@@ -47,7 +47,7 @@ public interface DeclarationConfig<THIS extends DeclarationConfig<THIS>> {
      * @param annotation the annotation to add to this declaration, must not be {@code null}
      * @return this configurator object, to allow fluent usage
      */
-    THIS addAnnotation(Annotation annotation);
+    DeclarationConfig addAnnotation(Annotation annotation);
 
     /**
      * Removes all annotations matching given predicate from this declaration.
@@ -55,12 +55,12 @@ public interface DeclarationConfig<THIS extends DeclarationConfig<THIS>> {
      * @param predicate an annotation predicate, must not be {@code null}
      * @return this configurator object, to allow fluent usage
      */
-    THIS removeAnnotation(Predicate<AnnotationInfo> predicate);
+    DeclarationConfig removeAnnotation(Predicate<AnnotationInfo> predicate);
 
     /**
      * Removes all annotations from this declaration.
      *
      * @return this configurator object, to allow fluent usage
      */
-    THIS removeAllAnnotations();
+    DeclarationConfig removeAllAnnotations();
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Discovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Discovery.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 1st phase of CDI Lite extension processing.
+ * 1st phase of CDI Lite extension execution.
  * Allow registering additional classes to be scanned during bean discovery.
  * Also allows registering custom CDI meta-annotations.
  * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 2nd phase of CDI Lite extension processing.
+ * 2nd phase of CDI Lite extension execution.
  * Allows transforming annotations.
  * <p>
  * Methods annotated {@code @Enhancement} must define exactly one parameter of one of these types:

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ExactType.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ExactType.java
@@ -8,21 +8,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Constraints the {@link Enhancement @Enhancement} or {@link Processing @Processing} method to given types.
+ * Constrains the {@link Enhancement @Enhancement} or {@link Processing @Processing} method to given types.
  * <p>
- * If the {@code @Enhancement} method has a parameter of type {@code ClassConfig},
+ * If the {@code @Enhancement} method has a parameter of type {@code ClassConfig} or {@code ClassInfo},
  * the method is called once for each given type.
- * If the {@code @Enhancement} method has a parameter of type {@code MethodConfig} or {@code FieldConfig},
- * the method is called once for each method or field of each given type.
+ * If the {@code @Enhancement} method has a parameter of type {@code MethodConfig}, {@code MethodInfo},
+ * {@code FieldConfig}, or {@code FieldInfo}, the method is called once for each method or field of each given type.
+ * TODO also inherited methods and fields? what about constructors?
  * <p>
  * If the {@code @Processing} method has a parameter of type {@code BeanInfo},
  * the method is called once for each bean whose set of bean types contains at least one given type.
  * If the {@code @Processing} method has a parameter of type {@code ObserverInfo},
- * the method is called once for each observer method whose observed type is among the given types.
+ * the method is called once for each observer whose observed event type is present in the set of given types.
  * <p>
- * If the {@code annotatedWith} attribute is set, only types that use given annotations are considered.
+ * If {@code annotatedWith} is set, only types that use given annotations are considered for {@code @Enhancement}.
  * The annotations can appear on the type, or on any member of the type, or any parameter of any member of the type.
- * This is ignored for {@code @Processing}.
+ * The value of {@code annotatedWith} is ignored for {@code @Processing}.
  *
  * @since 4.0
  */

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/FieldConfig.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/FieldConfig.java
@@ -1,6 +1,10 @@
 package jakarta.enterprise.inject.build.compatible.spi;
 
+import jakarta.enterprise.lang.model.AnnotationInfo;
 import jakarta.enterprise.lang.model.declarations.FieldInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Predicate;
 
 /**
  * Allows adding annotations to and removing annotations from a field.
@@ -10,7 +14,7 @@ import jakarta.enterprise.lang.model.declarations.FieldInfo;
  * @see Enhancement
  * @since 4.0
  */
-public interface FieldConfig extends DeclarationConfig<FieldConfig> {
+public interface FieldConfig extends DeclarationConfig {
     /**
      * Returns the {@link FieldInfo} corresponding to this transformed field.
      *
@@ -18,4 +22,51 @@ public interface FieldConfig extends DeclarationConfig<FieldConfig> {
      */
     @Override
     FieldInfo info();
+
+    /**
+     * Adds a marker annotation of given type to this field.
+     * Doesn't allow configuring annotation members.
+     *
+     * @param annotationType the annotation type, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    FieldConfig addAnnotation(Class<? extends Annotation> annotationType);
+
+    /**
+     * Adds given annotation to this field. The {@link AnnotationInfo} can be obtained
+     * from an annotation target, or constructed from scratch using {@link AnnotationBuilder}.
+     *
+     * @param annotation the annotation to add to this field, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    FieldConfig addAnnotation(AnnotationInfo annotation);
+
+    /**
+     * Adds given annotation to this field. The annotation instance is typically
+     * a subclass of {@link jakarta.enterprise.util.AnnotationLiteral AnnotationLiteral}.
+     *
+     * @param annotation the annotation to add to this field, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    FieldConfig addAnnotation(Annotation annotation);
+
+    /**
+     * Removes all annotations matching given predicate from this field.
+     *
+     * @param predicate an annotation predicate, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    FieldConfig removeAnnotation(Predicate<AnnotationInfo> predicate);
+
+    /**
+     * Removes all annotations from this field.
+     *
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    FieldConfig removeAllAnnotations();
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/InjectionPointInfo.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/InjectionPointInfo.java
@@ -28,8 +28,9 @@ public interface InjectionPointInfo {
     Collection<AnnotationInfo> qualifiers();
 
     /**
-     * Returns the declaration of this injection point. That is a {@link jakarta.enterprise.lang.model.declarations.FieldInfo FieldInfo}
-     * for field injection, or {@link jakarta.enterprise.lang.model.declarations.ParameterInfo ParameterInfo} for:
+     * Returns the declaration of this injection point.
+     * That is a {@link jakarta.enterprise.lang.model.declarations.FieldInfo FieldInfo} for field injection,
+     * or {@link jakarta.enterprise.lang.model.declarations.ParameterInfo ParameterInfo} for:
      * <ul>
      * <li>constructor injection,</li>
      * <li>initializer method,</li>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/MethodConfig.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/MethodConfig.java
@@ -1,6 +1,10 @@
 package jakarta.enterprise.inject.build.compatible.spi;
 
+import jakarta.enterprise.lang.model.AnnotationInfo;
 import jakarta.enterprise.lang.model.declarations.MethodInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Predicate;
 
 /**
  * Allows adding annotations to and removing annotations from a method.
@@ -10,7 +14,7 @@ import jakarta.enterprise.lang.model.declarations.MethodInfo;
  * @see Enhancement
  * @since 4.0
  */
-public interface MethodConfig extends DeclarationConfig<MethodConfig> {
+public interface MethodConfig extends DeclarationConfig {
     /**
      * Returns the {@link MethodInfo} corresponding to this transformed method.
      *
@@ -18,4 +22,51 @@ public interface MethodConfig extends DeclarationConfig<MethodConfig> {
      */
     @Override
     MethodInfo info();
+
+    /**
+     * Adds a marker annotation of given type to this method.
+     * Doesn't allow configuring annotation members.
+     *
+     * @param annotationType the annotation type, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    MethodConfig addAnnotation(Class<? extends Annotation> annotationType);
+
+    /**
+     * Adds given annotation to this method. The {@link AnnotationInfo} can be obtained
+     * from an annotation target, or constructed from scratch using {@link AnnotationBuilder}.
+     *
+     * @param annotation the annotation to add to this method, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    MethodConfig addAnnotation(AnnotationInfo annotation);
+
+    /**
+     * Adds given annotation to this method. The annotation instance is typically
+     * a subclass of {@link jakarta.enterprise.util.AnnotationLiteral AnnotationLiteral}.
+     *
+     * @param annotation the annotation to add to this method, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    MethodConfig addAnnotation(Annotation annotation);
+
+    /**
+     * Removes all annotations matching given predicate from this method.
+     *
+     * @param predicate an annotation predicate, must not be {@code null}
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    MethodConfig removeAnnotation(Predicate<AnnotationInfo> predicate);
+
+    /**
+     * Removes all annotations from this method.
+     *
+     * @return this configurator object, to allow fluent usage
+     */
+    @Override
+    MethodConfig removeAllAnnotations();
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ObserverInfo.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ObserverInfo.java
@@ -25,16 +25,16 @@ import jakarta.enterprise.event.TransactionPhase;
  */
 public interface ObserverInfo {
     /**
-     * Returns the type of events observed by this observer.
+     * Returns the observed event type of this observer.
      *
-     * @return the type of events observed by this observer, never {@code null}
+     * @return the observed event type of this observer, never {@code null}
      */
     Type observedType();
 
     /**
-     * Returns a collection of this observer's qualifiers, represented as {@link AnnotationInfo}.
+     * Returns a collection of observed event qualifiers, represented as {@link AnnotationInfo}.
      *
-     * @return immutable collection of qualifiers, never {@code null}
+     * @return immutable collection of observed event qualifiers, never {@code null}
      */
     // TODO method(s) for getting AnnotationInfo for given qualifier class?
     Collection<AnnotationInfo> qualifiers();
@@ -77,9 +77,7 @@ public interface ObserverInfo {
      *
      * @return whether this observer is synthetic
      */
-    default boolean isSynthetic() {
-        return bean() == null;
-    }
+    boolean isSynthetic();
 
     /**
      * Returns the priority of this observer. This is typically defined by adding

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Processing.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Processing.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 3rd phase of CDI Lite extension processing.
+ * 3rd phase of CDI Lite extension execution.
  * Allows processing registered beans and observers.
  * Note that synthetic beans and observers, registered in {@link Synthesis @Synthesis}, will <i>not</i> be processed.
  * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScopeInfo.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScopeInfo.java
@@ -3,8 +3,9 @@ package jakarta.enterprise.inject.build.compatible.spi;
 import jakarta.enterprise.lang.model.declarations.ClassInfo;
 
 /**
- * A scope of some bean. Scopes are expressed using {@linkplain #annotation() scope annotations}. Lifecycle
- * of beans with given scope is determined by a {@linkplain jakarta.enterprise.context.spi.Context context}.
+ * A scope of a bean. Scope type is an {@linkplain #annotation() annotation}, meta-annotated
+ * {@link jakarta.inject.Scope @Scope} or {@link jakarta.enterprise.context.NormalScope @NormalScope}.
+ * Lifecycle of beans with given scope is determined by a {@linkplain jakarta.enterprise.context.spi.Context context}.
  *
  * @since 4.0
  */
@@ -28,10 +29,10 @@ public interface ScopeInfo {
     }
 
     /**
-     * Returns whether this scope is normal. In other words, returns whether
+     * Returns whether this scope type is normal. In other words, returns whether
      * this scope annotation is meta-annotated {@code @NormalScope}.
      *
-     * @return whether this scope is normal
+     * @return whether this scope type is normal
      */
     boolean isNormal();
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SubtypesOf.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SubtypesOf.java
@@ -2,25 +2,36 @@ package jakarta.enterprise.inject.build.compatible.spi;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Constraints the {@link Enhancement @Enhancement} method to subtypes of given types.
- * If the {@code @Enhancement} method has a parameter of type {@code ClassConfig},
- * the method is called once for each subtype of each given type.
- * If the {@code @Enhancement} method has a parameter of type {@code MethodConfig} or {@code FieldConfig},
- * the method is called once for each method or field of each subtype of each given type.
+ * Constrains the {@link Enhancement @Enhancement} or {@link Processing @Processing} method to subtypes of given types.
  * <p>
- * If the {@code annotatedWith} attribute is set, only types that use given annotations are considered.
+ * If the {@code @Enhancement} method has a parameter of type {@code ClassConfig} or {@code ClassInfo},
+ * the method is called once for each subtype of each given type.
+ * If the {@code @Enhancement} method has a parameter of type {@code MethodConfig}, {@code MethodInfo},
+ * {@code FieldConfig}, or {@code FieldInfo}, the method is called once for each method or field
+ * of each subtype of each given type.
+ * TODO also inherited methods and fields? what about constructors?
+ * <p>
+ * If the {@code @Processing} method has a parameter of type {@code BeanInfo},
+ * the method is called once for each bean whose set of bean types contains at least one subtype of any given type.
+ * If the {@code @Processing} method has a parameter of type {@code ObserverInfo},
+ * the method is called once for each observer whose observed event type is present in the set of subtypes of any give type.
+ * <p>
+ * If {@code annotatedWith} is set, only types that use given annotations are considered for {@code @Enhancement}.
  * The annotations can appear on the type, or on any member of the type, or any parameter of any member of the type.
+ * The value of {@code annotatedWith} is ignored for {@code @Processing}.
  *
  * @since 4.0
  */
 // TODO should the given type itself also match? (in theory yes, as subtyping is reflexive)
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(SubtypesOf.List.class)
 public @interface SubtypesOf {
     Class<?> type();
 

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Synthesis.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Synthesis.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 4th phase of CDI Lite extension processing.
+ * 4th phase of CDI Lite extension execution.
  * Allows registering synthetic beans and observers.
  * <p>
  * Methods annotated {@code @Synthesis} can define parameters of these types:

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanBuilder.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanBuilder.java
@@ -7,78 +7,367 @@ import jakarta.enterprise.lang.model.types.Type;
 import java.lang.annotation.Annotation;
 
 /**
+ * Builder for synthetic beans.
  * Instances are not reusable. For each synthetic bean, new instance
  * must be created by {@link SyntheticComponents#addBean(Class)}.
  *
- * @param <T> type of bean instances
+ * @param <T> the bean class of this synthetic bean
  * @since 4.0
  */
 public interface SyntheticBeanBuilder<T> {
-    // TODO should have the type parameter? (see also SyntheticObserverBuilder and SyntheticComponents)
-
-    // can be called multiple times and is additive
-    // TODO methods to add multiple types at once?
+    /**
+     * Adds {@code type} to the set of bean types of this synthetic bean. This method may be called
+     * multiple times to add multiple bean types.
+     * <p>
+     * If not called, the set of bean types of this synthetic bean will be a singleton set
+     * containing {@code java.lang.Object}.
+     *
+     * @param type the bean type, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> type(Class<?> type);
 
+    /**
+     * Adds {@code type} to the set of bean types of this synthetic bean. This method may be called
+     * multiple times to add multiple bean types.
+     * <p>
+     * If not called, the set of bean types of this synthetic bean will be a singleton set
+     * containing {@code java.lang.Object}.
+     *
+     * @param type the bean type, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> type(ClassInfo type);
 
+    /**
+     * Adds {@code type} to the set of bean types of this synthetic bean. This method may be called
+     * multiple times to add multiple bean types.
+     * <p>
+     * If not called, the set of bean types of this synthetic bean will be a singleton set
+     * containing {@code java.lang.Object}.
+     *
+     * @param type the bean type, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> type(Type type);
 
-    // can be called multiple times and is additive
-    // TODO methods to add multiple qualifiers at once?
-    SyntheticBeanBuilder<T> qualifier(Class<? extends Annotation> annotationType); // for marker annotations
+    /**
+     * Adds a marker annotation of given type to the set of qualifiers of this synthetic bean.
+     * This method may be called multiple times to add multiple qualifiers.
+     * <p>
+     * If not called, this synthetic bean will have the {@code @Default} qualifier
+     * (and the {@code @Any} qualifier that all beans have).
+     *
+     * @param annotationType the type of the marker annotation, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
+    SyntheticBeanBuilder<T> qualifier(Class<? extends Annotation> annotationType);
 
+    /**
+     * Adds given annotation to the set of qualifiers of this synthetic bean.
+     * This method may be called multiple times to add multiple qualifiers.
+     * <p>
+     * If not called, this synthetic bean will have the {@code @Default} qualifier
+     * (and the {@code @Any} qualifier that all beans have).
+     *
+     * @param qualifierAnnotation the annotation, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> qualifier(AnnotationInfo qualifierAnnotation);
 
+    /**
+     * Adds given annotation to the set of qualifiers of this synthetic bean.
+     * This method may be called multiple times to add multiple qualifiers.
+     * <p>
+     * If not called, this synthetic bean will have the {@code @Default} qualifier
+     * (and the {@code @Any} qualifier that all beans have).
+     *
+     * @param qualifierAnnotation the annotation, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> qualifier(Annotation qualifierAnnotation);
 
-    // if called multiple times, last call wins
-    // if not called, defaults to @Dependent
+    /**
+     * Sets the scope of this synthetic bean to given scope type.
+     * <p>
+     * If not called, this synthetic bean will be {@code @Dependent}.
+     *
+     * @param scopeAnnotation the scope type, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     * @throws IllegalStateException if this method is called multiple times
+     */
     SyntheticBeanBuilder<T> scope(Class<? extends Annotation> scopeAnnotation);
 
-    // if called with `true`, priority is automatically 0, unless `priority` is also called
-    // if called multiple times, last call wins
+    /**
+     * Marks this synthetic bean as an alternative if desired. To make this synthetic bean
+     * an enabled alternative, call both {@code alternative(true)} and {@code priority(some priority)}.
+     * <p>
+     * If this synthetic bean is an alternative, not setting a priority means
+     * that it is not enabled, which is equivalent to not registering it at all.
+     * <p>
+     * If not called, this synthetic bean will not be an alternative.
+     *
+     * @param isAlternative whether this synthetic bean should be an alternative
+     * @return this {@code SyntheticBeanBuilder}
+     * @throws IllegalStateException if this method is called multiple times
+     */
     SyntheticBeanBuilder<T> alternative(boolean isAlternative);
 
-    // if called, alternative is automatically true
-    // if called multiple times, last call wins
+    /**
+     * Sets a priority of this synthetic bean. To make this synthetic bean an enabled alternative,
+     * call both {@code alternative(true)} and {@code priority(some priority)}.
+     * <p>
+     * If this synthetic bean is an alternative, not setting a priority means
+     * that it is not enabled, which is equivalent to not registering it at all.
+     * <p>
+     * If not called, this synthetic bean will not have a priority.
+     * If this synthetic bean is not an alternative, the priority is ignored.
+     *
+     * @param priority the priority of this synthetic bean
+     * @return this {@code SyntheticBeanBuilder}
+     * @throws IllegalStateException if this method is called multiple times
+     */
     SyntheticBeanBuilder<T> priority(int priority);
 
-    // EL name (equivalent to @Named), IIUC
-    // if called multiple times, last call wins
-    SyntheticBeanBuilder<T> name(String name);
+    /**
+     * Sets the bean name of this synthetic bean. If {@code beanName} is {@code null},
+     * this synthetic bean will not have a name.
+     * <p>
+     * If not called, this synthetic bean will not have a name.
+     *
+     * @param beanName the bean name of this synthetic bean
+     * @return this {@code SyntheticBeanBuilder}
+     * @throws IllegalStateException if this method is called multiple times
+     */
+    SyntheticBeanBuilder<T> name(String beanName);
 
-    // can be called multiple times and is additive
+    /**
+     * Adds {@code stereotypeAnnotation} to the set of stereotypes of this synthetic bean.
+     * This method may be called multiple times to add multiple stereotypes.
+     * <p>
+     * If not called, this synthetic bean will have no stereotype.
+     *
+     * @param stereotypeAnnotation the stereotype, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> stereotype(Class<? extends Annotation> stereotypeAnnotation);
 
+    /**
+     * Adds {@code stereotypeAnnotation} to the set of stereotypes of this synthetic bean.
+     * This method may be called multiple times to add multiple stereotypes.
+     * <p>
+     * If not called, this synthetic bean will have no stereotype.
+     *
+     * @param stereotypeAnnotation the stereotype, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> stereotype(ClassInfo stereotypeAnnotation);
 
-    // params for creation and destruction functions
+    /**
+     * Adds a {@code boolean}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, boolean value);
 
+    /**
+     * Adds a {@code boolean} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, boolean[] value);
 
+    /**
+     * Adds an {@code int}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, int value);
 
+    /**
+     * Adds an {@code int} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, int[] value);
 
+    /**
+     * Adds a {@code long}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, long value);
 
+    /**
+     * Adds a {@code long} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, long[] value);
 
+    /**
+     * Adds a {@code double}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, double value);
 
+    /**
+     * Adds a {@code double} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, double[] value);
 
+    /**
+     * Adds a {@code String}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, String value);
 
+    /**
+     * Adds a {@code String} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, String[] value);
 
+    /**
+     * Adds a {@code Class}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, Class<?> value);
+    // TODO add a variant that takes a `ClassInfo`? the value would be `Class` at runtime
 
+    /**
+     * Adds a {@code Class} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
     SyntheticBeanBuilder<T> withParam(String key, Class<?>[] value);
+    // TODO add a variant that takes a `ClassInfo[]`? the value would be `Class[]` at runtime
 
+    /**
+     * Adds an {@code annotation}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     * <p>
+     * When looked up from the parameter map in the creation/destruction function, the value will be
+     * an instance of the annotation type, <em>not</em> an {@code AnnotationInfo}.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
+    SyntheticBeanBuilder<T> withParam(String key, AnnotationInfo value);
+
+    /**
+     * Adds an {@code annotation}-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
+    SyntheticBeanBuilder<T> withParam(String key, Annotation value);
+
+    /**
+     * Adds an {@code annotation} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     * <p>
+     * When looked up from the parameter map in the creation/destruction function, the values will be
+     * instances of the corresponding annotation types, <em>not</em> {@code AnnotationInfo}.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
+    SyntheticBeanBuilder<T> withParam(String key, AnnotationInfo[] value);
+
+    /**
+     * Adds an {@code annotation} array-valued parameter to the map of construction/destruction parameters.
+     * The parameter map is passed to the {@linkplain SyntheticBeanCreator creation} and
+     * {@linkplain SyntheticBeanDisposer destruction} function when the bean is instantiated/disposed.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     */
+    SyntheticBeanBuilder<T> withParam(String key, Annotation[] value);
+
+    /**
+     * Sets the class of the synthetic bean {@linkplain SyntheticBeanCreator creation} function.
+     * The class must be {@code public} and have a {@code public} zero-parameter constructor.
+     * <p>
+     * If not called, the synthetic bean registration will fail.
+     *
+     * @param creatorClass the {@linkplain SyntheticBeanCreator creation} function class, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     * @throws IllegalStateException if this method is called multiple times
+     */
     SyntheticBeanBuilder<T> createWith(Class<? extends SyntheticBeanCreator<T>> creatorClass);
 
+    /**
+     * Sets the class of the synthetic bean {@linkplain SyntheticBeanDisposer destruction} function.
+     * The class must be {@code public} and have a {@code public} zero-parameter constructor.
+     * <p>
+     * If not called, a noop destruction function will be used.
+     *
+     * @param disposerClass the {@linkplain SyntheticBeanDisposer destruction} function class, must not be {@code null}
+     * @return this {@code SyntheticBeanBuilder}
+     * @throws IllegalStateException if this method is called multiple times
+     */
     SyntheticBeanBuilder<T> disposeWith(Class<? extends SyntheticBeanDisposer<T>> disposerClass);
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanCreator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanCreator.java
@@ -5,15 +5,29 @@ import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
 /**
+ * Creation function for a synthetic bean defined by {@link SyntheticBeanBuilder}.
  * Implementations must be {@code public} classes with a {@code public} zero-parameter constructor.
  *
- * @param <T> type of created instances
+ * @param <T> the bean class of the synthetic bean
  * @since 4.0
  */
 public interface SyntheticBeanCreator<T> {
     // TODO maybe a more high-level API that takes an Instance?
     //  compare with BeanConfigurator.createWith and BeanConfigurator.produceWith
 
-    // injectionPoint is only set when the synthetic bean is @Dependent
+    /**
+     * Creates an instance of the synthetic bean.
+     * <p>
+     * The parameter map is defined by the {@link SyntheticBeanBuilder}. Note that
+     * annotation-typed parameters are always passed to this function as instances of
+     * the annotation type, even if an instance of {@code AnnotationInfo} was passed
+     * to the {@code SyntheticBeanBuilder}.
+     *
+     * @param creationalContext the creational context, never {@code null}
+     * @param injectionPoint the injection point into which the new instance will be injected,
+     * or {@code null} if the synthetic bean is not {@code @Dependent}
+     * @param params immutable map of parameters, never {@code null}
+     * @return an instance of the bean, may only be {@code null} if the synthetic bean is {@code @Dependent}
+     */
     T create(CreationalContext<T> creationalContext, InjectionPoint injectionPoint, Map<String, Object> params);
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanDisposer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanDisposer.java
@@ -4,14 +4,27 @@ import java.util.Map;
 import jakarta.enterprise.context.spi.CreationalContext;
 
 /**
+ * Destruction function for a synthetic bean defined by {@link SyntheticBeanBuilder}.
  * Implementations must be {@code public} classes with a {@code public} zero-parameter constructor.
  *
- * @param <T> type of disposed instances
+ * @param <T> the bean class of the synthetic bean
  * @since 4.0
  */
 public interface SyntheticBeanDisposer<T> {
     // TODO maybe a more high-level API that takes an Instance?
     //  compare with BeanConfigurator.destroyWith and BeanConfigurator.disposeWith
 
+    /**
+     * Destroys an instance of the synthetic bean.
+     * <p>
+     * The parameter map is defined by the {@link SyntheticBeanBuilder}. Note that
+     * annotation-typed parameters are always passed to this function as instances of
+     * the annotation type, even if an instance of {@code AnnotationInfo} was passed
+     * to the {@code SyntheticBeanBuilder}.
+     *
+     * @param instance the synthetic bean instance, never {@code null} (TODO what if @Dependent?)
+     * @param creationalContext the creational context, never {@code null}
+     * @param params immutable map of parameters, never {@code null}
+     */
     void dispose(T instance, CreationalContext<T> creationalContext, Map<String, Object> params);
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticComponents.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticComponents.java
@@ -6,9 +6,27 @@ package jakarta.enterprise.inject.build.compatible.spi;
  * @since 4.0
  */
 public interface SyntheticComponents {
-    // TODO type parameters? (see also SyntheticBeanBuilder and SyntheticObserverBuilder)
+    /**
+     * Creates a {@link SyntheticBeanBuilder} that allows configuring a new synthetic bean
+     * of given {@code beanClass}. The synthetic bean will be registered at the end of
+     * the {@link Synthesis @Synthesis} method.
+     *
+     * @param beanClass the bean class of the new synthetic bean, must not be {@code null}
+     * @param <T> the bean class of the new synthetic bean
+     * @return a new {@link SyntheticBeanBuilder}, never {@code null}
+     */
+    <T> SyntheticBeanBuilder<T> addBean(Class<T> beanClass);
 
-    <T> SyntheticBeanBuilder<T> addBean(Class<T> implementationClass);
-
-    SyntheticObserverBuilder addObserver();
+    /**
+     * Creates a {@link SyntheticObserverBuilder} that allows configuring a new synthetic observer
+     * for given {@code eventType}. The synthetic observer will be registered at the end of
+     * the {@link Synthesis @Synthesis} method.
+     *
+     * @param eventType the observed event type of the new synthetic observer, must not be {@code null}
+     * @param <T> the observed event type of the new synthetic observer
+     * @return a new {@link SyntheticObserverBuilder}, never {@code null}
+     */
+    <T> SyntheticObserverBuilder<T> addObserver(Class<T> eventType);
+    // TODO is the class literal here bad for annotation processors perhaps? it shouldn't,
+    //  we do the same thing in `addBean`
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticObserver.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticObserver.java
@@ -1,15 +1,30 @@
 package jakarta.enterprise.inject.build.compatible.spi;
 
+import jakarta.enterprise.event.ObserverException;
 import jakarta.enterprise.inject.spi.EventContext;
 
+import java.util.Map;
+
 /**
+ * The event notification function for a synthetic observer defined by {@link SyntheticObserverBuilder}.
  * Implementations must be {@code public} classes with a {@code public} zero-parameter constructor.
  *
- * @param <T> type of observed event instances
- *
+ * @param <T> the observed event type of the synthetic observer
  * @since 4.0
  */
 public interface SyntheticObserver<T> {
-    // TODO throws Exception? compare with ObserverMethodConfigurator.EventConsumer.accept
-    void observe(EventContext<T> event);
+    /**
+     * Consumes an event. The {@link EventContext} provides access to the event payload,
+     * as well as the {@link jakarta.enterprise.inject.spi.EventMetadata EventMetadata}.
+     * <p>
+     * The parameter map is defined by the {@link SyntheticObserverBuilder}. Note that
+     * annotation-typed parameters are always passed to this function as instances of
+     * the annotation type, even if an instance of {@code AnnotationInfo} was passed
+     * to the {@code SyntheticObserverBuilder}.
+     *
+     * @param event the event context, never {@code null}
+     * @param params immutable map of parameters, never {@code null}
+     * @throws Exception checked exception will be wrapped and rethrown as an {@link ObserverException}
+     */
+    void observe(EventContext<T> event, Map<String, Object> params) throws Exception;
 }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Types.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Types.java
@@ -9,8 +9,6 @@ import jakarta.enterprise.lang.model.types.Type;
 import jakarta.enterprise.lang.model.types.VoidType;
 import jakarta.enterprise.lang.model.types.WildcardType;
 
-// TODO move to jakarta.enterprise.lang.model.types? probably not, it doesn't model any part of Java language
-
 /**
  * A factory interface for creating instances of {@link Type}.
  *

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Validation.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Validation.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 5th phase of CDI Lite extension processing.
+ * 5th phase of CDI Lite extension execution.
  * Allows custom validation.
  * <p>
  * Methods annotated {@code @Validation} can define parameters of these types:

--- a/api/src/main/java/jakarta/enterprise/lang/model/AnnotationMember.java
+++ b/api/src/main/java/jakarta/enterprise/lang/model/AnnotationMember.java
@@ -15,11 +15,13 @@ import java.util.List;
  * <li>nested {@link java.lang.annotation.Annotation Annotation}s;</li>
  * <li>arrays of previously mentioned types.</li>
  * </ul>
- * The {@link #kind()} method returns the kind of this annotation member value.
- * The {@code is*} methods (such as {@link #isBoolean()}) allow checking
- * if this annotation member value is of given kind. The {@code as*} methods
- * (such as {@link #asBoolean()} allow "unwrapping" this annotation member value,
+ * The {@link #kind()} method returns the kind of this annotation member value. The {@code is*} methods
+ * (such as {@link #isBoolean()}) allow checking if this annotation member value is of given kind.
+ * The {@code as*} methods (such as {@link #asBoolean()}) allow "unwrapping" this annotation member value,
  * if it is of the corresponding kind.
+ * <p>
+ * Note that the {@code as*} methods do not perform type conversion, so if this annotation member value
+ * is an {@code int}, calling {@code asLong()} will throw an exception.
  * <p>
  * Implementations of this interface are required to define the {@code equals} and {@code hashCode} methods.
  * Implementations of this interface are encouraged to define the {@code toString} method such that
@@ -31,12 +33,6 @@ import java.util.List;
  *
  * @since 4.0
  */
-// TODO do the as* methods allow coercion or not? E.g., does asLong return a long
-//  if the value is of kind int, or does it throw? Fortunately, this only applies
-//  to the numeric primitive types and maybe String. I currently left the numeric
-//  as* methods documented as coercing, while asString as not coercing, but this
-//  needs more discussion. I personally don't like coercion here and would always
-//  throw if the type mismatches.
 public interface AnnotationMember {
     /**
      * Name of the commonly used {@code value()} annotation member.
@@ -201,74 +197,74 @@ public interface AnnotationMember {
     }
 
     /**
-     * Returns this value as a boolean.
+     * Returns this value as a {@code boolean}.
      *
      * @return the boolean value
-     * @throws IllegalStateException if this annotation member value is not a boolean
+     * @throws IllegalStateException if this annotation member value is not a {@code boolean}
      */
     boolean asBoolean();
 
     /**
-     * Returns this value as a byte.
+     * Returns this value as a {@code byte}.
      *
      * @return the byte value
-     * @throws IllegalStateException if the value cannot be represented as a byte
+     * @throws IllegalStateException if this annotation member value is not a {@code byte}
      */
     byte asByte();
 
     /**
-     * Returns this value as a short.
+     * Returns this value as a {@code short}.
      *
      * @return the short value
-     * @throws IllegalStateException if the value cannot be represented as a short.
+     * @throws IllegalStateException if this annotation member value is not a {@code short}
      */
     short asShort();
 
     /**
-     * Returns this value as an int.
+     * Returns this value as an {@code int}.
      *
      * @return the int value
-     * @throws IllegalStateException if the value cannot be represented as an int.
+     * @throws IllegalStateException if this annotation member value is not an {@code int}
      */
     int asInt();
 
     /**
-     * Returns this value as a long.
+     * Returns this value as a {@code long}.
      *
      * @return the long value
-     * @throws IllegalStateException if the value cannot be represented as a long.
+     * @throws IllegalStateException if this annotation member value is not a {@code long}
      */
     long asLong();
 
     /**
-     * Returns this value as a float.
+     * Returns this value as a {@code float}.
      *
      * @return the float value
-     * @throws IllegalStateException if the value cannot be represented as a float.
+     * @throws IllegalStateException if this annotation member value is not a {@code float}
      */
     float asFloat();
 
     /**
-     * Returns this value as a double.
+     * Returns this value as a {@code double}.
      *
      * @return the double value
-     * @throws IllegalStateException if the value cannot be represented as a double.
+     * @throws IllegalStateException if this annotation member value is not a {@code double}
      */
     double asDouble();
 
     /**
-     * Returns this value as a char.
+     * Returns this value as a {@code char}.
      *
      * @return the char value
-     * @throws IllegalStateException if this annotation member value is not a char
+     * @throws IllegalStateException if this annotation member value is not a {@code char}
      */
     char asChar();
 
     /**
-     * Returns this value as a String.
+     * Returns this value as a {@code String}.
      *
      * @return the String value
-     * @throws IllegalStateException if this annotation member value is not a String
+     * @throws IllegalStateException if this annotation member value is not a {@code String}
      */
     String asString();
 

--- a/api/src/main/java/jakarta/enterprise/lang/model/declarations/MethodInfo.java
+++ b/api/src/main/java/jakarta/enterprise/lang/model/declarations/MethodInfo.java
@@ -59,6 +59,13 @@ public interface MethodInfo extends DeclarationInfo {
     List<TypeVariable> typeParameters();
 
     /**
+     * Returns whether this method is, in fact, a constructor.
+     *
+     * @return whether this method is, in fact, a constructor
+     */
+    boolean isConstructor();
+
+    /**
      * Returns whether this method is {@code static}.
      *
      * @return whether this method is {@code static}.


### PR DESCRIPTION
- documentation added for synthetic beans and observers; this was
  the last place where proper documentation was missing
- `DeclarationConfig` is no longer generic and `{Class,Method,Field}Config`
  explicitly override the configuration methods, so that users don't have to
  declare a useless type argument when using `DeclarationConfig`
- `AnnotationMember.as*` methods don't perform type conversions
- added `MethodInfo.isConstructor` to distinguish constructors
  from regular methods