### PR TITLE
Adjust wording of specification and API around @Priority usage on ste…

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
@@ -122,7 +122,7 @@ import java.lang.annotation.Target;
  * 
  * <p>
  * A stereotype may declare a {@link jakarta.annotation.Priority &#064;Priority} annotation, which specifies that
- * every bean with the stereotype has given priority. This enables and orders alternatives, interceptors, and decorators.
+ * every bean with the stereotype is enabled and has given priority.
  * </p>
  *
  * <pre>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/StereotypeInfo.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/StereotypeInfo.java
@@ -38,8 +38,8 @@ public interface StereotypeInfo {
 
     /**
      * Returns the priority value this stereotype declares using the {@link jakarta.annotation.Priority @Priority}
-     * meta-annotation. All alternatives and interceptors with this stereotype will be enabled for the application
-     * and ordered using this priority value (unless they declare priority explicitly).
+     * meta-annotation. Beans with this stereotype will be enabled for the application and ordered using this priority
+     * value (unless they declare priority explicitly).
      * <p>
      * Returns {@code null} if this stereotype is not meta-annotated {@code @Priority}.
      *

--- a/spec/src/main/asciidoc/core/definition.asciidoc
+++ b/spec/src/main/asciidoc/core/definition.asciidoc
@@ -840,7 +840,7 @@ public @interface Mock {}
 
 ===== Declaring stereotype with `@Priority`
 
-A stereotype may declare a `@Priority` annotation which functions as a means of enabling and ordering affected alternatives, interceptors, and decorators (in {cdi_full}).
+A stereotype may declare a `@Priority` annotation which functions as a means of enabling and ordering affected beans.
 
 If a bean declares two different stereotypes that declare different priority values, the bean must explicitly declare a `@Priority` annotation. If the bean does not explicitly declare priority, the container automatically detects the problem and treats it as a definition error.
 


### PR DESCRIPTION
…reotypes.

Follow up on #524 

This PR aligns the wording closely to what spec already uses. Instead of specifically listing options, it simply allows usage of this stereotype on beans.