### PR TITLE
add BeanConfigurator.priority

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanConfigurator.java
@@ -316,4 +316,20 @@ public interface BeanConfigurator<T> {
      */
     BeanConfigurator<T> alternative(boolean value);
 
+    /**
+     * Set the priority of the configured bean.
+     * By default, the configured bean does not have a priority.
+     * <p>
+     * This is equivalent to putting the {@link jakarta.annotation.Priority Priority}
+     * annotation to an actual bean class or making a custom
+     * {@link jakarta.enterprise.inject.spi.Bean Bean} class implement
+     * {@link jakarta.enterprise.inject.spi.Prioritized Prioritized}.
+     * <p>
+     * This method has no effect if the configured bean is not an alternative.
+     *
+     * @param priority the priority value
+     * @return self
+     */
+    BeanConfigurator<T> priority(int priority);
+
 }


### PR DESCRIPTION
This is to allow setting a priority for synthetic beans created
using `BeanConfigurator`.

I briefly considered if `priority` should be added to
`BeanAttributesConfigurator` as well, but that would have
a ripple effect. It also doesn't reflect the present reality.
A custom `Bean` implementation can be added a priority
by implementing the `Prioritized` interface. Adding only
`BeanConfigurator.priority` is a perfect mirror of that
in the configurator API.