### PR TITLE
Address the TODO in preface.

### DIFF
--- a/spec/src/main/asciidoc/preface.asciidoc
+++ b/spec/src/main/asciidoc/preface.asciidoc
@@ -3,13 +3,6 @@
 
 == Preface
 
-// TODO
-[NOTE]
-====
-This part has to be rewritten to present a consitent history of the spec
-====
-
-
 === Evaluation license
 
 include::license-{license}.asciidoc[]


### PR DESCRIPTION
Fixes #490 

A simple removal of TODO as discussed in the linked issue.