### PR TITLE
Address remaining TODOs for passivation mentions.

### DIFF
--- a/spec/src/main/asciidoc/core/events.asciidoc
+++ b/spec/src/main/asciidoc/core/events.asciidoc
@@ -193,9 +193,6 @@ The container must provide a built-in bean with:
 
 If an injection point of raw type `Event` is defined, the container automatically detects the problem and treats it as a definition error.
 
-The built-in implementation must be a passivation capable dependency, as defined in <<passivation_capable_dependency>>.
-// TODO move passivation to Full?
-
 [[observer_resolution]]
 
 === Observer resolution

--- a/spec/src/main/asciidoc/core/events_full.asciidoc
+++ b/spec/src/main/asciidoc/core/events_full.asciidoc
@@ -2,6 +2,19 @@
 
 == Events in {cdi_full}
 
+[[firing_events_full]]
+
+=== Firing events in {cdi_full}
+
+[[builtin_event_full]]
+
+==== The built-in `Event` in {cdi_full}
+
+In addition to rules defined in <<builtin_event>>, the following rule applies.
+
+The built-in implementation must be a passivation capable dependency, as defined in <<passivation_capable_dependency>>.
+
+
 [[observer_methods_full]]
 
 === Observer methods in {cdi_full}

--- a/spec/src/main/asciidoc/core/scopescontexts.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts.asciidoc
@@ -123,9 +123,6 @@ Extensions providing context implementations for normal scopes should implement 
 
 If the context object is inactive, the `get()` and `destroy()` methods must throw a `ContextNotActiveException`.
 
-When the container calls `get()` or `destroy()` for a context that is associated with a passivating scope it must ensure that the given instance of `Contextual`  and the instance of `CreationalContext`, if given, are serializable.
-// TODO move passivation to Full?
-
 The context object is responsible for destroying any contextual instance it creates by passing the instance to the `destroy()` method of the `Contextual` object representing the contextual type. A destroyed instance must not subsequently be returned by the `get()` method.
 
 The context object must pass the same instance of `CreationalContext` to `Contextual.destroy()` that it passed to `Contextual.create()` when it created the instance.

--- a/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
@@ -2,6 +2,14 @@
 
 == Scopes and contexts in {cdi_full}
 
+[[context_full]]
+
+=== The `Context` interface in {cdi_full}
+
+In addition to rules defined in <<context>>, the following rule applies.
+
+When the container calls `get()` or `destroy()` for a context that is associated with a passivating scope it must ensure that the given instance of `Contextual`  and the instance of `CreationalContext`, if given, are serializable.
+
 [[dependent_context_full]]
 
 === Dependent pseudo-scope in {cdi_full}


### PR DESCRIPTION
Fixes #486 

The third file mentioned in original issue (`injectionandresolution.asciidoc`) was already addressed in different commits.