### PR TITLE
Language model only returns runtime-retained annotations in build compatible extensions

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildCompatibleExtension.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildCompatibleExtension.java
@@ -42,6 +42,9 @@ package jakarta.enterprise.inject.build.compatible.spi;
  * CDI implementations are not required to accept custom implementations of any {@code jakarta.enterprise.lang.model}
  * or {@code jakarta.enterprise.inject.build.compatible.spi} interface. In other words, users may only use instances
  * of these interfaces that they previously obtained from the corresponding API. If not, non-portable behavior results.
+ * <p>
+ * In build compatible extensions, implementations of {@link jakarta.enterprise.lang.model.AnnotationTarget}
+ * only return annotations with the {@linkplain java.lang.annotation.RetentionPolicy#RUNTIME runtime} retention policy.
  *
  * @since 4.0
  */


### PR DESCRIPTION
The language model API itself doesn't specify what annotations are
accessible. In the CDI context, only runtime-retained annotations
make sense, because that's the only way all implementation strategies
can be consistent. That's because:

- purely runtime implementations, such as Weld, only have access
  to runtime-retained annotations;
- bytecode-based implementations, such as ArC, only have access
  to runtime-retained and class-retained annotations, but don't
  have access to source-retained annotations;
- annotation processing-based implementations, such as ODI, have
  access to all annotations.

An alternative would be to specify that the language model _always_
returns only runtime-retained annotations. That would be just fine
strictly from the CDI perspective, but unforeseen cases may exist
where the language model API would be useful, but nothing would
prevent providing access to class-retained or even source-retained
annotations. Hence, I believe it is better to make the restriction
on the CDI level, and not on the language model level.