### PR TITLE
Adjust Handle.get() behavior - throw exception if attempting to get()…

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/Instance.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Instance.java
@@ -281,6 +281,8 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
          * @return the contextual reference
          * @see Instance#get()
          * @throws IllegalStateException If the producing {@link Instance} does not exist
+         * @throws IllegalStateException If invoked on {@link Handle} that previously successfully destroyed its
+         * underlying contextual reference
          */
         T get();
 

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -701,7 +701,8 @@ public interface Handle<T> extends AutoCloseable {
 }
 ----
 
-The `get()` method returns a contextual reference object. The contextual reference is resolved lazily.
+The `get()` method returns a contextual reference object. The contextual reference is resolved lazily. Throws
+`IllegalStateException` if invoked on `Handle` that previously successfully destroyed its underlying contextual reference.
 
 The `getBean()` method returns the `Bean` object representing metadata of the given contextual instance.
 


### PR DESCRIPTION
… reference which was destroyed.

Related to https://github.com/eclipse-ee4j/cdi-tck/pull/308