### PR TITLE
Allow @Enhancement to not restrict the types based on annotations

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Discovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Discovery.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * 1st phase of {@linkplain BuildCompatibleExtension build compatible extension} execution.
- * Allow registering additional classes to be scanned during bean discovery.
+ * Allow adding additional classes to the set of types discovered during type discovery.
  * Also allows registering custom CDI meta-annotations.
  * <p>
  * Methods annotated {@code @Discovery} may declare parameters of these types:

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * In the following text, the term <em>expected types</em> denotes the set of types defined by
  * the {@link #types() types}, {@link #withSubtypes() withSubtypes} and {@link #withAnnotations() withAnnotations}
  * members of the {@code @Enhancement} annotation. The term <em>discovered types</em> denotes
- * the subset of <em>expected types</em> that were discovered during bean discovery.
+ * the subset of <em>expected types</em> that were discovered during type discovery.
  * <p>
  * Methods annotated {@code @Enhancement} must declare exactly one parameter of one of these types:
  * <ul>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
@@ -72,20 +72,24 @@ public @interface Enhancement {
      * parameter of any member of the type, or as a meta-annotation on any annotation
      * that is considered by these rules.
      * <p>
-     * Defaults to the {@linkplain BeanDefiningAnnotations set of bean defining annotations}.
+     * If empty, the set of <em>expected types</em> is not narrowed down in any way.
+     * If {@code java.lang.Annotation} is present, the set of <em>expected types</em>
+     * is narrowed down to types that use any annotation.
+     * The {@link BeanDefiningAnnotations @BeanDefiningAnnotations} marker type may
+     * be used to narrow down the set of <em>expected types</em> to types that use
+     * any bean defining annotation.
      * <p>
-     * If empty, or if {@code java.lang.Annotation} is present, all annotations are used.
-     * That is, the set of <em>expected types</em> is narrowed down to the set of types
-     * that use any annotation.
+     * Defaults to the {@linkplain BeanDefiningAnnotations set of bean defining annotations}.
      *
      * @return types of annotations that must be present on the <em>expected types</em>
      */
     Class<? extends Annotation>[] withAnnotations() default BeanDefiningAnnotations.class;
 
     /**
-     * Marker annotation type that represents set of bean defining annotations after
-     * the {@link Discovery @Discovery} phase is finished. That is, it includes custom
-     * normal scope annotations as well as custom stereotypes.
+     * Marker annotation type that, for the purpose of {@link Enhancement#withAnnotations()},
+     * represents set of bean defining annotations after the {@link Discovery @Discovery}
+     * phase is finished. That is, it includes custom normal scope annotations as well as
+     * custom stereotypes.
      */
     @interface BeanDefiningAnnotations {
     }

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
@@ -79,11 +79,12 @@ public @interface Enhancement {
      * be used to narrow down the set of <em>expected types</em> to types that use
      * any bean defining annotation.
      * <p>
-     * Defaults to the {@linkplain BeanDefiningAnnotations set of bean defining annotations}.
+     * Defaults to an empty array, so that the set of <em>expected types</em> is not
+     * narrowed down in any way.
      *
      * @return types of annotations that must be present on the <em>expected types</em>
      */
-    Class<? extends Annotation>[] withAnnotations() default BeanDefiningAnnotations.class;
+    Class<? extends Annotation>[] withAnnotations() default {};
 
     /**
      * Marker annotation type that, for the purpose of {@link Enhancement#withAnnotations()},

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScannedClasses.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScannedClasses.java
@@ -1,14 +1,16 @@
 package jakarta.enterprise.inject.build.compatible.spi;
 
 /**
- * Allows registering additional classes to be scanned during bean discovery.
- * Annotations on these classes can later be transformed using {@link Enhancement @Enhancement}.
+ * Allows adding additional classes to the set of types discovered during type discovery.
+ * Such classes will therefore be scanned during bean discovery. Annotations on these classes
+ * can later be transformed using {@link Enhancement @Enhancement}.
  *
  * @since 4.0
  */
 public interface ScannedClasses {
     /**
-     * Adds a class with given name to the set of classes to be scanned during bean discovery.
+     * Adds a class with given name to the set of types discovered during type discovery.
+     * The class will therefore be scanned during bean discovery.
      *
      * @param className binary name of the class, as defined by <cite>The Java&trade; Language Specification</cite>;
      * in other words, the class name as returned by {@link Class#getName()}


### PR DESCRIPTION
Fixes #564

I intentionally split this into 2 commits:

1. Make `@Enhancement(withAnnotations = {})` mean "no restriction on annotations". That is, types without annotations added through `@Discovery` may be subject to `@Enhancement`. The default is still `BeanDefiningAnnotations.class`.
2. Chagne the default value to an empty array, to align with Portable Extensions.

That's because I'm pretty sure we'd have a consensus on item 1, but not necessarily on item 2. 