### PR TITLE
Remove Enhancement.BeanDefiningAnnotations

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
@@ -75,9 +75,6 @@ public @interface Enhancement {
      * If empty, the set of <em>expected types</em> is not narrowed down in any way.
      * If {@code java.lang.Annotation} is present, the set of <em>expected types</em>
      * is narrowed down to types that use any annotation.
-     * The {@link BeanDefiningAnnotations @BeanDefiningAnnotations} marker type may
-     * be used to narrow down the set of <em>expected types</em> to types that use
-     * any bean defining annotation.
      * <p>
      * Defaults to an empty array, so that the set of <em>expected types</em> is not
      * narrowed down in any way.
@@ -85,13 +82,4 @@ public @interface Enhancement {
      * @return types of annotations that must be present on the <em>expected types</em>
      */
     Class<? extends Annotation>[] withAnnotations() default {};
-
-    /**
-     * Marker annotation type that, for the purpose of {@link Enhancement#withAnnotations()},
-     * represents set of bean defining annotations after the {@link Discovery @Discovery}
-     * phase is finished. That is, it includes custom normal scope annotations as well as
-     * custom stereotypes.
-     */
-    @interface BeanDefiningAnnotations {
-    }
 }


### PR DESCRIPTION
The marker annotation `@Enhancement.BeanDefiningAnnotations`
used to represent all bean defining annotations for the purpose
of restricting the set of types on which `@Enhancement` should
be performed. That, however, is pretty useless: `@Enhancement`
is only performed on types that were discovered during type
discovery, and all such types have a bean defining annotation.
(Either they have it directly, or `@Dependent` is implied
in case of classes added through `@Discovery` that don't have
a bean defining annotation.)