### PR TITLE
Make the return type of Instance.handles() covariant

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/Instance.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Instance.java
@@ -252,14 +252,14 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      *
      * @return a new iterable
      */
-    Iterable<Handle<T>> handles();
+    Iterable<? extends Handle<T>> handles();
 
     /**
      *  Returns stream of {@link Handle} objects.
      *
      * @return a new stream of contextual reference handles
      */
-    default Stream<Handle<T>> handlesStream() {
+    default Stream<? extends Handle<T>> handlesStream() {
         return StreamSupport.stream(handles().spliterator(), false);
     }
 


### PR DESCRIPTION
The `Instance.handles()` method returns an `Iterable` of contextual
reference handles (`Instance.Handle<T>`). It used to be defined in
an invariant way (`Iterable<Handle<T>>`), which prevents CDI Lite
implementations from exposing subtypes of `Instance` and
`Instance.Handle` as public API. This commit changes the return
type to covariant `Iterable<? extends Handle<T>>`. With that change,
CDI Lite implementations can expose a `CustomInstance`, which extends
`Instance` and overrides the `Instance.handles()` method. The method,
in turn, can return `Iterable<CustomInstanceHandle<T>>`, where
`CustomInstanceHandle` extends `Instance.Handle`.