### PR TITLE
Specify that duplicate type discovery is non-portable

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScannedClasses.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScannedClasses.java
@@ -11,6 +11,9 @@ public interface ScannedClasses {
     /**
      * Adds a class with given name to the set of types discovered during type discovery.
      * The class will therefore be scanned during bean discovery.
+     * <p>
+     * Adding the same class multiple times, or adding a class that is automatically discovered
+     * by the container, leads to non-portable behavior.
      *
      * @param className binary name of the class, as defined by <cite>The Java&trade; Language Specification</cite>;
      * in other words, the class name as returned by {@link Class#getName()}


### PR DESCRIPTION
This is because `ScannedClasses` may be implemented on top of
Portable Extensions using `BeforeBeanDiscovery.addAnnotatedType`,
which doesn't specify what happens when the same identifier
is used multiple times, and doesn't provide a portable way
to "override" the type that was discovered by the container.