### PR TITLE
Improve ambiguous dependency resolution spec working

### DIFF
--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -106,7 +106,7 @@ An _unsatisfied dependency_ exists at an injection point when no bean is eligibl
 An _ambiguous dependency_ exists at an injection point when multiple beans are eligible for injection to the injection point.
 
 When an ambiguous dependency exists, the container attempts to resolve the ambiguity.
-The container eliminates all eligible beans that are not alternatives selected for the application, except for producer methods and fields of beans that are alternatives.
+The container eliminates all eligible beans that are not alternatives selected for the application, and selects only those producer methods and fields of beans that are alternatives.
 If:
 
 * there is exactly one bean remaining, the container will select this bean, and the ambiguous dependency is called resolvable.

--- a/spec/src/main/asciidoc/core/injectionandresolution_full.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution_full.asciidoc
@@ -149,7 +149,7 @@ A special set of rules, defined in <<delegate_assignable_parameters>>, apply if 
 In addition to rules defined in <<ambig_names>>, the following rules apply.
 
 When an ambiguous name exists, the container attempts to resolve the ambiguity.
-The container eliminates all eligible beans that are not alternatives selected for the bean archive or selected for the application, except for producer methods and fields of beans that are alternatives.
+The container eliminates all eligible beans that are not alternatives selected for the application, and selects only those producer methods and fields of beans that are alternatives.
 
 [[client_proxies_full]]
 


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

I find this wording confusing and am at least trying to understand if not clarify the intent.
This might seem pedantic but maybe this is just a beginner's POV.

Does my new text capture the correct meaning?  If so, I think it is a better wording.

If we say "A" is the set of  "eligible beans that are not alternatives selected for the application" and "B" is the set of " producer methods and fields of beans that are alternatives."... then I think the spec is saying the CDI impl eliminates the set A and takes the set B.  

But you can read this a certain way to say that the CDI impl eliminates "A - B", i.e. that B is some subset of A that we do NOT eliminate.    And maybe you're thinking that makes no sense.. but I'm just saying it could be clearer.

Of possibly I am completely misunderstanding.
