### PR TITLE
Move the session scope to CDI Full

### DIFF
--- a/spec/src/main/asciidoc/core/definition.asciidoc
+++ b/spec/src/main/asciidoc/core/definition.asciidoc
@@ -482,7 +482,7 @@ public class Order { ... }
 
 [NOTE]
 ====
-Conversations are only available in {cdi_full}.
+Session scope and conversation scope are only available in {cdi_full}.
 ====
 
 A list that contains the results of a search screen might be represented by a request scoped object:
@@ -499,9 +499,9 @@ The set of scope types is extensible.
 
 ==== Built-in scope types
 
-There are four standard scope types defined in {cdi_lite}, all defined in the package `jakarta.enterprise.context`.
+There are three standard scope types defined in {cdi_lite}, all defined in the package `jakarta.enterprise.context`.
 
-* The container must provide an implementation of the `@RequestScoped`, `@ApplicationScoped` and `@SessionScoped` annotations defined in <<builtin_contexts>>.
+* The container must provide an implementation of the `@RequestScoped` and `@ApplicationScoped` annotations defined in <<builtin_contexts>>.
 Note that these standard scopes can be extended by third-party extensions as defined in <<context>>
 * Finally, there is a `@Dependent` pseudo-scope for dependent objects, as defined in <<dependent_context>>.
 
@@ -602,7 +602,7 @@ A bean class with a _bean defining annotation_ is said to be an _implicit bean_.
 
 The set of bean defining annotations contains:
 
-* `@ApplicationScoped`, `@SessionScoped` and `@RequestScoped` annotations,
+* `@ApplicationScoped` and `@RequestScoped` annotations,
 * all other normal scope types,
 * `@Interceptor` annotation,
 * all stereotype annotations (i.e. annotations annotated with `@Stereotype`),

--- a/spec/src/main/asciidoc/core/definition_full.asciidoc
+++ b/spec/src/main/asciidoc/core/definition_full.asciidoc
@@ -1,6 +1,6 @@
 [[concepts_full]]
 
-{cdi_full} contains all the functionality defined in {cdi_lite} and adds some additional features such as specialization, decorators or conversation scope.
+{cdi_full} contains all the functionality defined in {cdi_lite} and adds some additional features such as specialization, decorators, session scope or conversation scope.
 Some of these concepts were briefly mentioned in the previous {cdi_lite} chapter and this section of specification defines them in depth.
 
 [[scopes_full]]
@@ -11,8 +11,9 @@ Some of these concepts were briefly mentioned in the previous {cdi_lite} chapter
 
 === Built-in scope types in {cdi_full}
 
-In addition to built-in scope types defined in <<builtin_scopes>>, the following built-in scope is present:
+In addition to built-in scope types defined in <<builtin_scopes>>, the following two built-in scopes are present:
 
+* The `@SessionScoped` annotation represents the session scope defined in <<session_context_full>>.
 * The `@ConversationScoped` annotation represents the conversation scope defined in <<conversation_context_full>>.
 
 In addition to rules defined in <<builtin_scopes>>, the following rules apply.
@@ -25,7 +26,7 @@ If a decorator has any scope other than `@Dependent`, non-portable behavior resu
 
 In addition to bean defining annotations defined in <<bean_defining_annotations>>, the following bean defining annotations are present:
 
-* `@ConversationScoped` annotation,
+* `@SessionScoped` and `@ConversationScoped` annotations,
 * `@Decorator` annotation.
 
 [[builtin_stereotypes_full]]

--- a/spec/src/main/asciidoc/core/implementation.asciidoc
+++ b/spec/src/main/asciidoc/core/implementation.asciidoc
@@ -469,6 +469,11 @@ public class Order {
 }
 ----
 
+[NOTE]
+====
+Session scope and conversation scope are only available in {cdi_full}.
+====
+
 If a bean class does not explicitly declare a constructor using `@Inject`, the constructor that accepts no parameters is the bean constructor.
 
 If a bean class has more than one constructor annotated `@Inject`, the container automatically detects the problem and treats it as a definition error.

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -293,7 +293,7 @@ A client proxy implements/extends some or all of the bean types of the bean and 
 There are a number of reasons for this indirection:
 
 * The container must guarantee that when any valid injected reference to a bean of normal scope is invoked, the invocation is always processed by the current instance of the injected bean.
-In certain scenarios, for example if a request scoped bean is injected into a session scoped bean, or into a servlet, this rule requires an indirect reference.
+In certain scenarios, for example if a request scoped bean is injected into an application scoped bean, or into a servlet, this rule requires an indirect reference.
 (Note that the `@Dependent` pseudo-scope is not a normal scope.)
 * The container may use a client proxy when creating beans with circular dependencies.
 This is only necessary when the circular dependencies are initialized via a managed bean constructor or producer method parameter.

--- a/spec/src/main/asciidoc/core/lifecycle.asciidoc
+++ b/spec/src/main/asciidoc/core/lifecycle.asciidoc
@@ -27,7 +27,7 @@ In the following example, a producer method returns instances of other beans:
 
 [source, java]
 ----
-@SessionScoped
+@RequestScoped
 public class PaymentStrategyProducer implements Serializable {
    
    private PaymentStrategyType paymentStrategyType;
@@ -56,7 +56,7 @@ But in this example, the returned objects are not contextual instances:
 
 [source, java]
 ----
-@SessionScoped
+@RequestScoped
 public class PaymentStrategyProducer implements Serializable {
    
    private PaymentStrategyType paymentStrategyType;

--- a/spec/src/main/asciidoc/core/scopescontexts.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts.asciidoc
@@ -377,12 +377,6 @@ The request context is destroyed:
 * after the invocation of an asynchronous observer method completes, and
 * after the `@PostConstruct` callback completes, if it did not already exist when the `@PostConstruct` callback occurred.
 
-[[session_context]]
-
-==== Session context lifecycle
-
-The _session context_ is provided by a built-in context object for the built-in scope type `@SessionScoped`.
-
 [[application_context]]
 
 ==== Application context lifecycle

--- a/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
@@ -115,7 +115,7 @@ A _passivating scope_ requires that:
 
 Passivating scopes must be explicitly declared `@NormalScope(passivating=true)`.
 
-For example, the built-in session and conversation scopes defined in <<builtin_contexts>> are passivating scopes.
+For example, the built-in session and conversation scopes defined in <<builtin_contexts_full>> are passivating scopes.
 No other built-in scopes are passivating scopes.
 
 [[passivation_validation]]
@@ -158,9 +158,7 @@ If a managed bean which declares a passivating scope type, has a decorator or in
 
 [[session_context_full]]
 
-==== Session context lifecycle in {cdi_full}
-
-The rules defined in <<session_context>> are overridden as follows.
+==== Session context lifecycle
 
 The _session context_ is provided by a built-in context object for the built-in passivating scope type `@SessionScoped`.
 


### PR DESCRIPTION
When I was reviewing the remaining CDI 4.0 work, I realized we kept the session scope in CDI Lite. I believe it should be moved to CDI Full, because:

- the session scope is not actually defined at all in Core CDI
- the definition in CDI EE heavily relies on the Servlet API, which isn't even proposed to be part of the Jakarta EE 10 Core Profile (per https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10CoreProfileRelasePlan)
- modern application architectures often don't rely on in-memory HTTP sessions at all (and we've deliberately left passivation out of Lite)

Hence, I'm proposing this PR to remove the session scope from Lite. It stays in Full.