### PR TITLE
Add ObserverMethod#getDeclaringBean method.

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
@@ -56,6 +56,16 @@ public interface ObserverMethod<T> extends Prioritized {
     public Class<?> getBeanClass();
 
     /**
+     * <p>
+     * Obtains the {@linkplain Bean bean} that declares the observer method.
+     * For synthetic observers, the return value is undefined.
+     * </p>
+     *
+     * @return the declaring {@linkplain Bean bean}
+     */
+    public Bean<?> getDeclaringBean();
+
+    /**
      * Obtains the {@linkplain jakarta.enterprise.event observed event type}.
      * 
      * @return the observed event {@linkplain Type type}

--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -114,6 +114,7 @@ The interface `jakarta.enterprise.inject.spi.ObserverMethod` defines everything 
 ----
 public interface ObserverMethod<T> extends Prioritized {
     public Class<?> getBeanClass();
+    public Bean<?> getDeclaringBean();
     public Type getObservedType();
     public Set<Annotation> getObservedQualifiers();
     public Reception getReception();
@@ -126,6 +127,7 @@ public interface ObserverMethod<T> extends Prioritized {
 ----
 
 * `getBeanClass()` returns the class of the type that declares the observer method.
+* `getDeclaringBean()` returns the `Bean` object that declares the observer method. Return value is undefined for synthetic observers.
 * `getObservedType()` and `getObservedQualifiers()` return the observed event type and qualifiers.
 * `getReception()` returns `IF_EXISTS` for a conditional observer and `ALWAYS` otherwise.
 * `getTransactionPhase()` returns the appropriate transaction phase for a transactional observer method or `IN_PROGRESS` otherwise.


### PR DESCRIPTION
Fixes #563 

I am deliberately keeping the return value for synth observers undefined because I understand some implementations can choose to return `null` but in Weld this is apparently never the case and instead synth. OMs belong to the extension declaring them.