### PR TITLE
Add default implementation of OM#getDeclaringBean()

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
@@ -61,9 +61,16 @@ public interface ObserverMethod<T> extends Prioritized {
      * For synthetic observers, the return value is undefined.
      * </p>
      *
+     * <p>
+     * For the sake of compatibility with existing custom {@link ObserverMethod} implementations, this method by default
+     * returns {@code null}.
+     * </p>
+     *
      * @return the declaring {@linkplain Bean bean}
      */
-    public Bean<?> getDeclaringBean();
+    default Bean<?> getDeclaringBean() {
+        return null;
+    }
 
     /**
      * Obtains the {@linkplain jakarta.enterprise.event observed event type}.


### PR DESCRIPTION
A follow up of PR - https://github.com/eclipse-ee4j/cdi/pull/578
Related to issue - #563 

Going over existing code, I realized that this would be a breaking change for any existing custom impl of `ObserverMethod`.
Making the method default and returning `null` will help avoid that, plus `null` is a valid return value for synthetic OMs anyway.