### PR TITLE
Invalid parameter combinations in @Enhancement and @Registration meth…

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Enhancement.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * in {@link jakarta.enterprise.lang.model.declarations.ClassInfo#fields() ClassInfo.fields}.
  * <p>
  * If the {@code @Enhancement} method doesn't declare any parameter of one of these types,
- * or if it declares more than one, the container treats it as a deployment problem.
+ * or if it declares more than one, the container treats it as a definition error.
  * <p>
  * Additionally, methods annotated {@code @Enhancement} may declare parameters of these types:
  * <ul>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Registration.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Registration.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * has a parameter of type {@code BeanInfo}, it will be called for interceptors as well.
  * <p>
  * If the {@code @Registration} method doesn't declare any parameter of one of these types,
- * or if it declares more than one, the container treats it as a deployment problem.
+ * or if it declares more than one, the container treats it as a definition error.
  * <p>
  * Additionally, methods annotated {@code @Registration} may declare parameters of these types:
  * <ul>


### PR DESCRIPTION
…ods should be treated as definition errors.

As I pointed out in https://github.com/eclipse-ee4j/cdi-tck/pull/329, I think we should handle these cases as definition errors.