### PR TITLE
Update package version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -335,8 +335,8 @@
 					<instructions>
 						<Automatic-Module-Name>jakarta.cdi</Automatic-Module-Name>
 						<Export-Package>
-							jakarta.decorator;version=3.0,
-							jakarta.enterprise.*;version=3.0,
+							jakarta.decorator;version=4.0,
+							jakarta.enterprise.*;version=4.0,
 						</Export-Package>
 						<Import-Package>
 							jakarta.el; version=4.0,


### PR DESCRIPTION
The package versions should be updated accordingly for this new release. At the moment, they were still on the same version as the CDI 3.0 release. Since this spec does not use semantic versioning, I have simply updated the major versions.